### PR TITLE
fix: resolve github codeql security vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@owpz/ksuid",
-  "version": "1.0.0",
+  "version": "25.7.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@owpz/ksuid",
-      "version": "1.0.0",
+      "version": "25.7.20",
       "license": "MIT",
       "dependencies": {
         "base-x": "^5.0.0"
@@ -15,6 +15,7 @@
         "ksuid": "dist/cli.js"
       },
       "devDependencies": {
+        "@eslint/js": "^9.31.0",
         "@types/eslint": "^9.6.1",
         "@types/node": "^24.0.15",
         "@typescript-eslint/eslint-plugin": "^8.37.0",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "base-x": "^5.0.0"
   },
   "devDependencies": {
+    "@eslint/js": "^9.31.0",
     "@types/eslint": "^9.6.1",
     "@types/node": "^24.0.15",
     "@typescript-eslint/eslint-plugin": "^8.37.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,1288 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      base-x:
+        specifier: ^5.0.0
+        version: 5.0.1
+    devDependencies:
+      '@types/eslint':
+        specifier: ^9.6.1
+        version: 9.6.1
+      '@types/node':
+        specifier: ^24.0.15
+        version: 24.1.0
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^8.37.0
+        version: 8.38.0(@typescript-eslint/parser@8.38.0(eslint@9.31.0)(typescript@5.8.3))(eslint@9.31.0)(typescript@5.8.3)
+      '@typescript-eslint/parser':
+        specifier: ^8.37.0
+        version: 8.38.0(eslint@9.31.0)(typescript@5.8.3)
+      eslint:
+        specifier: ^9.31.0
+        version: 9.31.0
+      eslint-config-prettier:
+        specifier: ^10.1.8
+        version: 10.1.8(eslint@9.31.0)
+      eslint-plugin-prettier:
+        specifier: ^5.5.3
+        version: 5.5.3(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.31.0))(eslint@9.31.0)(prettier@3.6.2)
+      prettier:
+        specifier: ^3.6.2
+        version: 3.6.2
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@types/node@24.1.0)(typescript@5.8.3)
+      typescript:
+        specifier: ^5.8.3
+        version: 5.8.3
+      uvu:
+        specifier: ^0.5.6
+        version: 0.5.6
+
+packages:
+
+  '@cspotcode/source-map-support@0.8.1':
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
+
+  '@eslint-community/eslint-utils@4.7.0':
+    resolution: {integrity: sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+  '@eslint-community/regexpp@4.12.1':
+    resolution: {integrity: sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/config-array@0.21.0':
+    resolution: {integrity: sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/config-helpers@0.3.0':
+    resolution: {integrity: sha512-ViuymvFmcJi04qdZeDc2whTHryouGcDlaxPqarTD0ZE10ISpxGUVZGZDx4w01upyIynL3iu6IXH2bS1NhclQMw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/core@0.15.1':
+    resolution: {integrity: sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/eslintrc@3.3.1':
+    resolution: {integrity: sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/js@9.31.0':
+    resolution: {integrity: sha512-LOm5OVt7D4qiKCqoiPbA7LWmI+tbw1VbTUowBcUMgQSuM6poJufkFkYDcQpo5KfgD39TnNySV26QjOh7VFpSyw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/object-schema@2.1.6':
+    resolution: {integrity: sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/plugin-kit@0.3.4':
+    resolution: {integrity: sha512-Ul5l+lHEcw3L5+k8POx6r74mxEYKG5kOb6Xpy2gCRW6zweT6TEhAf8vhxGgjhqrd/VO/Dirhsb+1hNpD1ue9hw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@humanfs/core@0.19.1':
+    resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/node@0.16.6':
+    resolution: {integrity: sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanwhocodes/module-importer@1.0.1':
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
+
+  '@humanwhocodes/retry@0.3.1':
+    resolution: {integrity: sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==}
+    engines: {node: '>=18.18'}
+
+  '@humanwhocodes/retry@0.4.3':
+    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
+    engines: {node: '>=18.18'}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.4':
+    resolution: {integrity: sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==}
+
+  '@jridgewell/trace-mapping@0.3.9':
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
+
+  '@pkgr/core@0.2.9':
+    resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
+    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+
+  '@tsconfig/node10@1.0.11':
+    resolution: {integrity: sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==}
+
+  '@tsconfig/node12@1.0.11':
+    resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
+
+  '@tsconfig/node14@1.0.3':
+    resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
+
+  '@tsconfig/node16@1.0.4':
+    resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
+
+  '@types/eslint@9.6.1':
+    resolution: {integrity: sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/node@24.1.0':
+    resolution: {integrity: sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==}
+
+  '@typescript-eslint/eslint-plugin@8.38.0':
+    resolution: {integrity: sha512-CPoznzpuAnIOl4nhj4tRr4gIPj5AfKgkiJmGQDaq+fQnRJTYlcBjbX3wbciGmpoPf8DREufuPRe1tNMZnGdanA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.38.0
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.9.0'
+
+  '@typescript-eslint/parser@8.38.0':
+    resolution: {integrity: sha512-Zhy8HCvBUEfBECzIl1PKqF4p11+d0aUJS1GeUiuqK9WmOug8YCmC4h4bjyBvMyAMI9sbRczmrYL5lKg/YMbrcQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.9.0'
+
+  '@typescript-eslint/project-service@8.38.0':
+    resolution: {integrity: sha512-dbK7Jvqcb8c9QfH01YB6pORpqX1mn5gDZc9n63Ak/+jD67oWXn3Gs0M6vddAN+eDXBCS5EmNWzbSxsn9SzFWWg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <5.9.0'
+
+  '@typescript-eslint/scope-manager@8.38.0':
+    resolution: {integrity: sha512-WJw3AVlFFcdT9Ri1xs/lg8LwDqgekWXWhH3iAF+1ZM+QPd7oxQ6jvtW/JPwzAScxitILUIFs0/AnQ/UWHzbATQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.38.0':
+    resolution: {integrity: sha512-Lum9RtSE3EroKk/bYns+sPOodqb2Fv50XOl/gMviMKNvanETUuUcC9ObRbzrJ4VSd2JalPqgSAavwrPiPvnAiQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <5.9.0'
+
+  '@typescript-eslint/type-utils@8.38.0':
+    resolution: {integrity: sha512-c7jAvGEZVf0ao2z+nnz8BUaHZD09Agbh+DY7qvBQqLiz8uJzRgVPj5YvOh8I8uEiH8oIUGIfHzMwUcGVco/SJg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.9.0'
+
+  '@typescript-eslint/types@8.38.0':
+    resolution: {integrity: sha512-wzkUfX3plUqij4YwWaJyqhiPE5UCRVlFpKn1oCRn2O1bJ592XxWJj8ROQ3JD5MYXLORW84063z3tZTb/cs4Tyw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.38.0':
+    resolution: {integrity: sha512-fooELKcAKzxux6fA6pxOflpNS0jc+nOQEEOipXFNjSlBS6fqrJOVY/whSn70SScHrcJ2LDsxWrneFoWYSVfqhQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <5.9.0'
+
+  '@typescript-eslint/utils@8.38.0':
+    resolution: {integrity: sha512-hHcMA86Hgt+ijJlrD8fX0j1j8w4C92zue/8LOPAFioIno+W0+L7KqE8QZKCcPGc/92Vs9x36w/4MPTJhqXdyvg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.9.0'
+
+  '@typescript-eslint/visitor-keys@8.38.0':
+    resolution: {integrity: sha512-pWrTcoFNWuwHlA9CvlfSsGWs14JxfN1TH25zM5L7o0pRLhsoZkDnTsXfQRJBEWJoV5DL0jf+Z+sxiud+K0mq1g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  acorn-walk@8.3.4:
+    resolution: {integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==}
+    engines: {node: '>=0.4.0'}
+
+  acorn@8.15.0:
+    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  ajv@6.12.6:
+    resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  arg@4.1.3:
+    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  base-x@5.0.1:
+    resolution: {integrity: sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==}
+
+  brace-expansion@1.1.12:
+    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
+
+  brace-expansion@2.0.2:
+    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
+  callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  create-require@1.1.1:
+    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  debug@4.4.1:
+    resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-is@0.1.4:
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
+  diff@4.0.2:
+    resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
+    engines: {node: '>=0.3.1'}
+
+  diff@5.2.0:
+    resolution: {integrity: sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==}
+    engines: {node: '>=0.3.1'}
+
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+
+  eslint-config-prettier@10.1.8:
+    resolution: {integrity: sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==}
+    hasBin: true
+    peerDependencies:
+      eslint: '>=7.0.0'
+
+  eslint-plugin-prettier@5.5.3:
+    resolution: {integrity: sha512-NAdMYww51ehKfDyDhv59/eIItUVzU0Io9H2E8nHNGKEeeqlnci+1gCvrHib6EmZdf6GxF+LCV5K7UC65Ezvw7w==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      '@types/eslint': '>=8.0.0'
+      eslint: '>=8.0.0'
+      eslint-config-prettier: '>= 7.0.0 <10.0.0 || >=10.1.0'
+      prettier: '>=3.0.0'
+    peerDependenciesMeta:
+      '@types/eslint':
+        optional: true
+      eslint-config-prettier:
+        optional: true
+
+  eslint-scope@8.4.0:
+    resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@4.2.1:
+    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint@9.31.0:
+    resolution: {integrity: sha512-QldCVh/ztyKJJZLr4jXNUByx3gR+TDYZCRXEktiZoUR3PGy4qCmSbkxcIle8GEwGpb5JBZazlaJ/CxLidXdEbQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
+  espree@10.4.0:
+    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  esquery@1.6.0:
+    resolution: {integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==}
+    engines: {node: '>=0.10'}
+
+  esrecurse@4.3.0:
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-diff@1.3.0:
+    resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
+
+  fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
+
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-levenshtein@2.0.6:
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fastq@1.19.1:
+    resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
+
+  file-entry-cache@8.0.0:
+    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
+    engines: {node: '>=16.0.0'}
+
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
+
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
+  flat-cache@4.0.1:
+    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
+    engines: {node: '>=16'}
+
+  flatted@3.3.3:
+    resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
+
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+
+  globals@14.0.0:
+    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
+
+  graphemer@1.4.0:
+    resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  ignore@5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  ignore@7.0.5:
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
+    engines: {node: '>= 4'}
+
+  import-fresh@3.3.1:
+    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
+    engines: {node: '>=6'}
+
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  js-yaml@4.1.0:
+    resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
+    hasBin: true
+
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-stable-stringify-without-jsonify@1.0.1:
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  kleur@4.1.5:
+    resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
+    engines: {node: '>=6'}
+
+  levn@0.4.1:
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
+
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
+
+  lodash.merge@4.6.2:
+    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  make-error@1.3.6:
+    resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
+
+  merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
+
+  minimatch@3.1.2:
+    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+
+  minimatch@9.0.5:
+    resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  mri@1.2.0:
+    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
+    engines: {node: '>=4'}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  natural-compare@1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  optionator@0.9.4:
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
+
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+
+  parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  picomatch@2.3.1:
+    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+    engines: {node: '>=8.6'}
+
+  prelude-ls@1.2.1:
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
+
+  prettier-linter-helpers@1.0.0:
+    resolution: {integrity: sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==}
+    engines: {node: '>=6.0.0'}
+
+  prettier@3.6.2:
+    resolution: {integrity: sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
+
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  sade@1.8.1:
+    resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
+    engines: {node: '>=6'}
+
+  semver@7.7.2:
+    resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  strip-json-comments@3.1.1:
+    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
+    engines: {node: '>=8'}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  synckit@0.11.11:
+    resolution: {integrity: sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+
+  ts-api-utils@2.1.0:
+    resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
+
+  ts-node@10.9.2:
+    resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+
+  type-check@0.4.0:
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
+
+  typescript@5.8.3:
+    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@7.8.0:
+    resolution: {integrity: sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==}
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  uvu@0.5.6:
+    resolution: {integrity: sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  v8-compile-cache-lib@3.0.1:
+    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
+
+  yn@3.1.1:
+    resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
+    engines: {node: '>=6'}
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
+
+snapshots:
+
+  '@cspotcode/source-map-support@0.8.1':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
+
+  '@eslint-community/eslint-utils@4.7.0(eslint@9.31.0)':
+    dependencies:
+      eslint: 9.31.0
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/regexpp@4.12.1': {}
+
+  '@eslint/config-array@0.21.0':
+    dependencies:
+      '@eslint/object-schema': 2.1.6
+      debug: 4.4.1
+      minimatch: 3.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/config-helpers@0.3.0': {}
+
+  '@eslint/core@0.15.1':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  '@eslint/eslintrc@3.3.1':
+    dependencies:
+      ajv: 6.12.6
+      debug: 4.4.1
+      espree: 10.4.0
+      globals: 14.0.0
+      ignore: 5.3.2
+      import-fresh: 3.3.1
+      js-yaml: 4.1.0
+      minimatch: 3.1.2
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/js@9.31.0': {}
+
+  '@eslint/object-schema@2.1.6': {}
+
+  '@eslint/plugin-kit@0.3.4':
+    dependencies:
+      '@eslint/core': 0.15.1
+      levn: 0.4.1
+
+  '@humanfs/core@0.19.1': {}
+
+  '@humanfs/node@0.16.6':
+    dependencies:
+      '@humanfs/core': 0.19.1
+      '@humanwhocodes/retry': 0.3.1
+
+  '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/retry@0.3.1': {}
+
+  '@humanwhocodes/retry@0.4.3': {}
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.4': {}
+
+  '@jridgewell/trace-mapping@0.3.9':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.4
+
+  '@nodelib/fs.scandir@2.1.5':
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.walk@1.2.8':
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.19.1
+
+  '@pkgr/core@0.2.9': {}
+
+  '@tsconfig/node10@1.0.11': {}
+
+  '@tsconfig/node12@1.0.11': {}
+
+  '@tsconfig/node14@1.0.3': {}
+
+  '@tsconfig/node16@1.0.4': {}
+
+  '@types/eslint@9.6.1':
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/json-schema': 7.0.15
+
+  '@types/estree@1.0.8': {}
+
+  '@types/json-schema@7.0.15': {}
+
+  '@types/node@24.1.0':
+    dependencies:
+      undici-types: 7.8.0
+
+  '@typescript-eslint/eslint-plugin@8.38.0(@typescript-eslint/parser@8.38.0(eslint@9.31.0)(typescript@5.8.3))(eslint@9.31.0)(typescript@5.8.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.1
+      '@typescript-eslint/parser': 8.38.0(eslint@9.31.0)(typescript@5.8.3)
+      '@typescript-eslint/scope-manager': 8.38.0
+      '@typescript-eslint/type-utils': 8.38.0(eslint@9.31.0)(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.38.0(eslint@9.31.0)(typescript@5.8.3)
+      '@typescript-eslint/visitor-keys': 8.38.0
+      eslint: 9.31.0
+      graphemer: 1.4.0
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.1.0(typescript@5.8.3)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@8.38.0(eslint@9.31.0)(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.38.0
+      '@typescript-eslint/types': 8.38.0
+      '@typescript-eslint/typescript-estree': 8.38.0(typescript@5.8.3)
+      '@typescript-eslint/visitor-keys': 8.38.0
+      debug: 4.4.1
+      eslint: 9.31.0
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.38.0(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.38.0(typescript@5.8.3)
+      '@typescript-eslint/types': 8.38.0
+      debug: 4.4.1
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/scope-manager@8.38.0':
+    dependencies:
+      '@typescript-eslint/types': 8.38.0
+      '@typescript-eslint/visitor-keys': 8.38.0
+
+  '@typescript-eslint/tsconfig-utils@8.38.0(typescript@5.8.3)':
+    dependencies:
+      typescript: 5.8.3
+
+  '@typescript-eslint/type-utils@8.38.0(eslint@9.31.0)(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.38.0
+      '@typescript-eslint/typescript-estree': 8.38.0(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.38.0(eslint@9.31.0)(typescript@5.8.3)
+      debug: 4.4.1
+      eslint: 9.31.0
+      ts-api-utils: 2.1.0(typescript@5.8.3)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/types@8.38.0': {}
+
+  '@typescript-eslint/typescript-estree@8.38.0(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.38.0(typescript@5.8.3)
+      '@typescript-eslint/tsconfig-utils': 8.38.0(typescript@5.8.3)
+      '@typescript-eslint/types': 8.38.0
+      '@typescript-eslint/visitor-keys': 8.38.0
+      debug: 4.4.1
+      fast-glob: 3.3.3
+      is-glob: 4.0.3
+      minimatch: 9.0.5
+      semver: 7.7.2
+      ts-api-utils: 2.1.0(typescript@5.8.3)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.38.0(eslint@9.31.0)(typescript@5.8.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.31.0)
+      '@typescript-eslint/scope-manager': 8.38.0
+      '@typescript-eslint/types': 8.38.0
+      '@typescript-eslint/typescript-estree': 8.38.0(typescript@5.8.3)
+      eslint: 9.31.0
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/visitor-keys@8.38.0':
+    dependencies:
+      '@typescript-eslint/types': 8.38.0
+      eslint-visitor-keys: 4.2.1
+
+  acorn-jsx@5.3.2(acorn@8.15.0):
+    dependencies:
+      acorn: 8.15.0
+
+  acorn-walk@8.3.4:
+    dependencies:
+      acorn: 8.15.0
+
+  acorn@8.15.0: {}
+
+  ajv@6.12.6:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  arg@4.1.3: {}
+
+  argparse@2.0.1: {}
+
+  balanced-match@1.0.2: {}
+
+  base-x@5.0.1: {}
+
+  brace-expansion@1.1.12:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  brace-expansion@2.0.2:
+    dependencies:
+      balanced-match: 1.0.2
+
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
+  callsites@3.1.0: {}
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  concat-map@0.0.1: {}
+
+  create-require@1.1.1: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  debug@4.4.1:
+    dependencies:
+      ms: 2.1.3
+
+  deep-is@0.1.4: {}
+
+  dequal@2.0.3: {}
+
+  diff@4.0.2: {}
+
+  diff@5.2.0: {}
+
+  escape-string-regexp@4.0.0: {}
+
+  eslint-config-prettier@10.1.8(eslint@9.31.0):
+    dependencies:
+      eslint: 9.31.0
+
+  eslint-plugin-prettier@5.5.3(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.31.0))(eslint@9.31.0)(prettier@3.6.2):
+    dependencies:
+      eslint: 9.31.0
+      prettier: 3.6.2
+      prettier-linter-helpers: 1.0.0
+      synckit: 0.11.11
+    optionalDependencies:
+      '@types/eslint': 9.6.1
+      eslint-config-prettier: 10.1.8(eslint@9.31.0)
+
+  eslint-scope@8.4.0:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
+  eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@4.2.1: {}
+
+  eslint@9.31.0:
+    dependencies:
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.31.0)
+      '@eslint-community/regexpp': 4.12.1
+      '@eslint/config-array': 0.21.0
+      '@eslint/config-helpers': 0.3.0
+      '@eslint/core': 0.15.1
+      '@eslint/eslintrc': 3.3.1
+      '@eslint/js': 9.31.0
+      '@eslint/plugin-kit': 0.3.4
+      '@humanfs/node': 0.16.6
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.8
+      '@types/json-schema': 7.0.15
+      ajv: 6.12.6
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.1
+      escape-string-regexp: 4.0.0
+      eslint-scope: 8.4.0
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
+      esquery: 1.6.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.2
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    transitivePeerDependencies:
+      - supports-color
+
+  espree@10.4.0:
+    dependencies:
+      acorn: 8.15.0
+      acorn-jsx: 5.3.2(acorn@8.15.0)
+      eslint-visitor-keys: 4.2.1
+
+  esquery@1.6.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  esrecurse@4.3.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  estraverse@5.3.0: {}
+
+  esutils@2.0.3: {}
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-diff@1.3.0: {}
+
+  fast-glob@3.3.3:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+
+  fast-json-stable-stringify@2.1.0: {}
+
+  fast-levenshtein@2.0.6: {}
+
+  fastq@1.19.1:
+    dependencies:
+      reusify: 1.1.0
+
+  file-entry-cache@8.0.0:
+    dependencies:
+      flat-cache: 4.0.1
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
+
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+
+  flat-cache@4.0.1:
+    dependencies:
+      flatted: 3.3.3
+      keyv: 4.5.4
+
+  flatted@3.3.3: {}
+
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  glob-parent@6.0.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  globals@14.0.0: {}
+
+  graphemer@1.4.0: {}
+
+  has-flag@4.0.0: {}
+
+  ignore@5.3.2: {}
+
+  ignore@7.0.5: {}
+
+  import-fresh@3.3.1:
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+
+  imurmurhash@0.1.4: {}
+
+  is-extglob@2.1.1: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  is-number@7.0.0: {}
+
+  isexe@2.0.0: {}
+
+  js-yaml@4.1.0:
+    dependencies:
+      argparse: 2.0.1
+
+  json-buffer@3.0.1: {}
+
+  json-schema-traverse@0.4.1: {}
+
+  json-stable-stringify-without-jsonify@1.0.1: {}
+
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
+
+  kleur@4.1.5: {}
+
+  levn@0.4.1:
+    dependencies:
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
+
+  lodash.merge@4.6.2: {}
+
+  make-error@1.3.6: {}
+
+  merge2@1.4.1: {}
+
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.1
+
+  minimatch@3.1.2:
+    dependencies:
+      brace-expansion: 1.1.12
+
+  minimatch@9.0.5:
+    dependencies:
+      brace-expansion: 2.0.2
+
+  mri@1.2.0: {}
+
+  ms@2.1.3: {}
+
+  natural-compare@1.4.0: {}
+
+  optionator@0.9.4:
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+      word-wrap: 1.2.5
+
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
+
+  parent-module@1.0.1:
+    dependencies:
+      callsites: 3.1.0
+
+  path-exists@4.0.0: {}
+
+  path-key@3.1.1: {}
+
+  picomatch@2.3.1: {}
+
+  prelude-ls@1.2.1: {}
+
+  prettier-linter-helpers@1.0.0:
+    dependencies:
+      fast-diff: 1.3.0
+
+  prettier@3.6.2: {}
+
+  punycode@2.3.1: {}
+
+  queue-microtask@1.2.3: {}
+
+  resolve-from@4.0.0: {}
+
+  reusify@1.1.0: {}
+
+  run-parallel@1.2.0:
+    dependencies:
+      queue-microtask: 1.2.3
+
+  sade@1.8.1:
+    dependencies:
+      mri: 1.2.0
+
+  semver@7.7.2: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  strip-json-comments@3.1.1: {}
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  synckit@0.11.11:
+    dependencies:
+      '@pkgr/core': 0.2.9
+
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
+
+  ts-api-utils@2.1.0(typescript@5.8.3):
+    dependencies:
+      typescript: 5.8.3
+
+  ts-node@10.9.2(@types/node@24.1.0)(typescript@5.8.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 24.1.0
+      acorn: 8.15.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.8.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+
+  type-check@0.4.0:
+    dependencies:
+      prelude-ls: 1.2.1
+
+  typescript@5.8.3: {}
+
+  undici-types@7.8.0: {}
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
+
+  uvu@0.5.6:
+    dependencies:
+      dequal: 2.0.3
+      diff: 5.2.0
+      kleur: 4.1.5
+      sade: 1.8.1
+
+  v8-compile-cache-lib@3.0.1: {}
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  word-wrap@1.2.5: {}
+
+  yn@3.1.1: {}
+
+  yocto-queue@0.1.0: {}

--- a/src/compressed-set.ts
+++ b/src/compressed-set.ts
@@ -106,9 +106,9 @@ export class CompressedSet {
     pos += 20;
 
     let timestamp = uniqueIds[0].timestamp;
-    let lastKSUID = uniqueIds[0];
     let lastValue = Uint128.uint128Payload(uniqueIds[0].toBuffer());
 
+    let lastKSUID = uniqueIds[0]; // Initialize when needed
     for (let i = 1; i < uniqueIds.length; i++) {
       const id = uniqueIds[i];
 
@@ -184,7 +184,6 @@ export class CompressedSet {
       }
 
       // Update state for next iteration
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       lastKSUID = id;
       lastValue = v;
     }

--- a/src/compressed-set.ts
+++ b/src/compressed-set.ts
@@ -108,7 +108,7 @@ export class CompressedSet {
     let timestamp = uniqueIds[0].timestamp;
     let lastValue = Uint128.uint128Payload(uniqueIds[0].toBuffer());
 
-    let lastKSUID = uniqueIds[0]; // Initialize when needed
+    let _lastKSUID = uniqueIds[0]; // Initialize when needed
     for (let i = 1; i < uniqueIds.length; i++) {
       const id = uniqueIds[i];
 
@@ -168,7 +168,7 @@ export class CompressedSet {
             if (i < uniqueIds.length) {
               const newId = uniqueIds[i];
               lastValue = Uint128.uint128Payload(newId.toBuffer());
-              lastKSUID = newId;
+              _lastKSUID = newId;
             } else {
               break; // We've processed all remaining IDs
             }
@@ -184,7 +184,7 @@ export class CompressedSet {
       }
 
       // Update state for next iteration
-      lastKSUID = id;
+      _lastKSUID = id;
       lastValue = v;
     }
 

--- a/src/uint128.ts
+++ b/src/uint128.ts
@@ -10,8 +10,8 @@ export class Uint128 {
 
   constructor(low: bigint, high: bigint) {
     // Ensure values are within uint64 bounds - explicit BigInt conversion to avoid implicit conversion warnings
-    this.low = BigInt(low) & U64_MAX;
-    this.high = BigInt(high) & U64_MAX;
+    this.low = BigInt(low ?? 0n) & U64_MAX;
+    this.high = BigInt(high ?? 0n) & U64_MAX;
   }
 
   static makeUint128(high: bigint, low: bigint): Uint128 {
@@ -90,7 +90,7 @@ export class Uint128 {
 
   sub(other: Uint128): Uint128 {
     // Subtract with borrow handling
-    let newLow = this.low - other.low;
+    let newLow = BigInt(this.low) - BigInt(other.low);
     let borrow = 0n;
 
     if (newLow < 0n) {
@@ -113,7 +113,7 @@ export class Uint128 {
   }
 
   decr(): Uint128 {
-    let newLow = this.low - 1n;
+    let newLow = BigInt(this.low) - 1n;
     let borrow = 0n;
 
     if (newLow < 0n) {
@@ -126,19 +126,19 @@ export class Uint128 {
   }
 
   compare(other: Uint128): number {
-    if (this.high < other.high) return -1;
-    if (this.high > other.high) return 1;
-    if (this.low < other.low) return -1;
-    if (this.low > other.low) return 1;
+    if (BigInt(this.high) < BigInt(other.high)) return -1;
+    if (BigInt(this.high) > BigInt(other.high)) return 1;
+    if (BigInt(this.low) < BigInt(other.low)) return -1;
+    if (BigInt(this.low) > BigInt(other.low)) return 1;
     return 0;
   }
 
   equals(other: Uint128): boolean {
-    return this.low === other.low && this.high === other.high;
+    return BigInt(this.low) === BigInt(other.low) && BigInt(this.high) === BigInt(other.high);
   }
 
   isZero(): boolean {
-    return this.low === 0n && this.high === 0n;
+    return BigInt(this.low) === 0n && BigInt(this.high) === 0n;
   }
 
   toString(): string {

--- a/src/uint128.ts
+++ b/src/uint128.ts
@@ -134,7 +134,10 @@ export class Uint128 {
   }
 
   equals(other: Uint128): boolean {
-    return BigInt(this.low) === BigInt(other.low) && BigInt(this.high) === BigInt(other.high);
+    return (
+      BigInt(this.low) === BigInt(other.low) &&
+      BigInt(this.high) === BigInt(other.high)
+    );
   }
 
   isZero(): boolean {

--- a/src/uint128.ts
+++ b/src/uint128.ts
@@ -5,13 +5,13 @@ const U64_MAX = 0xffffffffffffffffn;
 
 export class Uint128 {
   // Store as [low, high] to match Go's uint128 [2]uint64 layout
-  constructor(
-    private readonly low: bigint,
-    private readonly high: bigint
-  ) {
-    // Ensure values are within uint64 bounds
-    this.low = low & U64_MAX;
-    this.high = high & U64_MAX;
+  private readonly low: bigint;
+  private readonly high: bigint;
+
+  constructor(low: bigint, high: bigint) {
+    // Ensure values are within uint64 bounds - explicit BigInt conversion to avoid implicit conversion warnings
+    this.low = BigInt(low) & U64_MAX;
+    this.high = BigInt(high) & U64_MAX;
   }
 
   static makeUint128(high: bigint, low: bigint): Uint128 {
@@ -80,10 +80,11 @@ export class Uint128 {
 
   add(other: Uint128): Uint128 {
     // Add with carry handling
-    const lowSum = this.low + other.low;
+    const lowSum = BigInt(this.low) + BigInt(other.low);
     const carry = lowSum > U64_MAX ? 1n : 0n;
-    const newLow = lowSum & U64_MAX;
-    const newHigh = (this.high + other.high + carry) & U64_MAX;
+    const newLow = BigInt(lowSum) & U64_MAX;
+    const newHigh =
+      BigInt(BigInt(this.high) + BigInt(other.high) + carry) & U64_MAX;
     return new Uint128(newLow, newHigh);
   }
 
@@ -97,14 +98,18 @@ export class Uint128 {
       borrow = 1n;
     }
 
-    const newHigh = (this.high - other.high - borrow) & U64_MAX;
+    const newHigh =
+      BigInt(BigInt(this.high) - BigInt(other.high) - borrow) & U64_MAX;
     return new Uint128(newLow, newHigh);
   }
 
   incr(): Uint128 {
-    const newLow = this.low + 1n;
+    const newLow = BigInt(this.low) + 1n;
     const carry = newLow > U64_MAX ? 1n : 0n;
-    return new Uint128(newLow & U64_MAX, (this.high + carry) & U64_MAX);
+    return new Uint128(
+      BigInt(newLow) & U64_MAX,
+      BigInt(BigInt(this.high) + carry) & U64_MAX
+    );
   }
 
   decr(): Uint128 {
@@ -116,7 +121,7 @@ export class Uint128 {
       borrow = 1n;
     }
 
-    const newHigh = (this.high - borrow) & U64_MAX;
+    const newHigh = BigInt(BigInt(this.high) - borrow) & U64_MAX;
     return new Uint128(newLow, newHigh);
   }
 

--- a/test/api-contract/api-contract.test.ts
+++ b/test/api-contract/api-contract.test.ts
@@ -341,7 +341,7 @@ test("Sorting functions API contract", () => {
 
   // sort(KSUID[]): void (sorts in place)
   const ksuidsToSort = [...ksuids]; // make a copy
-  const sortResult = sort(ksuidsToSort);
+  const sortResult: void = sort(ksuidsToSort); // Explicitly test void return
   assert.is(sortResult, undefined); // sort returns void
   assert.is(ksuidsToSort.length, ksuids.length);
   ksuidsToSort.forEach(ksuid => assert.ok(ksuid instanceof KSUID));

--- a/test/api-contract/cli-contract.test.ts
+++ b/test/api-contract/cli-contract.test.ts
@@ -1,7 +1,6 @@
 import { test } from "uvu";
 import * as assert from "uvu/assert";
 import { spawn } from "child_process";
-import { promisify } from "util";
 
 /**
  * CLI API Contract Tests

--- a/test/api-contract/type-contract.test.ts
+++ b/test/api-contract/type-contract.test.ts
@@ -301,14 +301,14 @@ test("Sorting function signatures", () => {
 
   // Usage
   const ksuidsToSort = [...ksuids];
-  const sorted: void = sort(ksuidsToSort);
+  const sortResult = sort(ksuidsToSort); // sort returns void
   const checkSorted: boolean = isSorted(ksuids);
   const comparison: number = compare(ksuids[0], ksuids[1]);
 
   assert.type(sortFn, "function");
   assert.type(isSortedFn, "function");
   assert.type(compareFn, "function");
-  assert.is(sorted, undefined);
+  assert.is(sortResult, undefined);
   assert.type(checkSorted, "boolean");
   assert.type(comparison, "number");
 });

--- a/test/compare-implementations.ts
+++ b/test/compare-implementations.ts
@@ -71,128 +71,129 @@ const NEXT_PREV_VECTORS = [
 
 function compareBasicGeneration() {
   console.log("=== BASIC GENERATION COMPARISON ===\n");
-  
+
   let allPassed = true;
-  
+
   for (const testCase of GO_TEST_VECTORS) {
     console.log(`Testing: ${testCase.description}`);
-    
+
     const payload = Buffer.from(testCase.payload, "hex");
     const tsKsuid = KSUID.fromParts(testCase.timestamp, payload);
-    
+
     // Compare timestamp extraction
     const extractedTimestamp = tsKsuid.timestamp;
     console.log(`  Input timestamp: ${testCase.timestamp}`);
     console.log(`  Extracted timestamp: ${extractedTimestamp}`);
     const timestampMatch = extractedTimestamp === testCase.timestamp;
     console.log(`  ✓ Timestamp match: ${timestampMatch}`);
-    
+
     // Compare string representation
     const tsString = tsKsuid.toString();
     console.log(`  Expected string: ${testCase.expectedString}`);
     console.log(`  Generated string: ${tsString}`);
     const stringMatch = tsString === testCase.expectedString;
     console.log(`  ✓ String match: ${stringMatch}`);
-    
+
     // Compare raw buffer
     const tsRaw = tsKsuid.toBuffer().toString("hex");
     console.log(`  Expected raw: ${testCase.expectedRaw}`);
     console.log(`  Generated raw: ${tsRaw}`);
     const rawMatch = tsRaw === testCase.expectedRaw;
     console.log(`  ✓ Raw bytes match: ${rawMatch}`);
-    
+
     // Compare payload extraction
     const extractedPayload = tsKsuid.payload.toString("hex");
     console.log(`  Input payload: ${testCase.payload}`);
     console.log(`  Extracted payload: ${extractedPayload}`);
     const payloadMatch = extractedPayload === testCase.payload;
     console.log(`  ✓ Payload match: ${payloadMatch}`);
-    
-    const testPassed = timestampMatch && stringMatch && rawMatch && payloadMatch;
+
+    const testPassed =
+      timestampMatch && stringMatch && rawMatch && payloadMatch;
     console.log(`  → Test Result: ${testPassed ? "PASS" : "FAIL"}\n`);
-    
+
     if (!testPassed) allPassed = false;
   }
-  
+
   return allPassed;
 }
 
 function compareNextPrevOperations() {
   console.log("=== NEXT/PREV OPERATIONS COMPARISON ===\n");
-  
+
   let allPassed = true;
-  
+
   for (const testCase of NEXT_PREV_VECTORS) {
     console.log(`Testing: ${testCase.description}`);
-    
+
     const ksuid = KSUID.parse(testCase.input);
     const next = ksuid.next();
     const prev = ksuid.prev();
-    
+
     console.log(`  Input: ${testCase.input}`);
     console.log(`  Expected next: ${testCase.expectedNext}`);
     console.log(`  Generated next: ${next.toString()}`);
     const nextMatch = next.toString() === testCase.expectedNext;
     console.log(`  ✓ Next match: ${nextMatch}`);
-    
+
     console.log(`  Expected prev: ${testCase.expectedPrev}`);
     console.log(`  Generated prev: ${prev.toString()}`);
     const prevMatch = prev.toString() === testCase.expectedPrev;
     console.log(`  ✓ Prev match: ${prevMatch}`);
-    
+
     const testPassed = nextMatch && prevMatch;
     console.log(`  → Test Result: ${testPassed ? "PASS" : "FAIL"}\n`);
-    
+
     if (!testPassed) allPassed = false;
   }
-  
+
   return allPassed;
 }
 
 function compareTimestampConversion() {
   console.log("=== TIMESTAMP CONVERSION COMPARISON ===\n");
-  
+
   const KSUID_EPOCH = 1400000000; // 2014-05-13T16:53:20Z
-  
+
   const testCases = [
     { ksuidTimestamp: 0, description: "KSUID epoch" },
     { ksuidTimestamp: 95004740, description: "Standard timestamp" },
     { ksuidTimestamp: 4294967295, description: "Maximum timestamp" },
   ];
-  
+
   let allPassed = true;
-  
+
   for (const testCase of testCases) {
     console.log(`Testing: ${testCase.description}`);
-    
+
     const ksuid = KSUID.fromParts(testCase.ksuidTimestamp, Buffer.alloc(16, 0));
     const extractedTimestamp = ksuid.timestamp;
     const unixTimestamp = extractedTimestamp + KSUID_EPOCH;
     const expectedUnixTimestamp = testCase.ksuidTimestamp + KSUID_EPOCH;
-    
+
     console.log(`  KSUID timestamp: ${testCase.ksuidTimestamp}`);
     console.log(`  Extracted timestamp: ${extractedTimestamp}`);
     console.log(`  Calculated Unix timestamp: ${unixTimestamp}`);
     console.log(`  Expected Unix timestamp: ${expectedUnixTimestamp}`);
-    
+
     const timestampMatch = extractedTimestamp === testCase.ksuidTimestamp;
     const unixMatch = unixTimestamp === expectedUnixTimestamp;
-    
+
     console.log(`  ✓ KSUID timestamp match: ${timestampMatch}`);
     console.log(`  ✓ Unix timestamp match: ${unixMatch}`);
-    
+
     const testPassed = timestampMatch && unixMatch;
     console.log(`  → Test Result: ${testPassed ? "PASS" : "FAIL"}\n`);
-    
+
     if (!testPassed) allPassed = false;
   }
-  
+
   return allPassed;
 }
 
 function compareSequenceGeneration() {
   console.log("=== SEQUENCE GENERATION COMPARISON ===\n");
-  
+
   // Go sequence test vectors
   const expectedSequence = [
     "0o5sKzFDBc56T8mbUP8wH1KpSX7",
@@ -201,68 +202,82 @@ function compareSequenceGeneration() {
     "0o5sKzFDBc56T8mbUP8wH1KpSXA",
     "0o5sKzFDBc56T8mbUP8wH1KpSXB",
   ];
-  
+
   // Generate sequence using next() method
   let current = KSUID.parse(expectedSequence[0]);
   const tsSequence = [current.toString()];
-  
+
   for (let i = 1; i < expectedSequence.length; i++) {
     current = current.next();
     tsSequence.push(current.toString());
   }
-  
+
   console.log("Comparing sequence generation:");
   let allPassed = true;
-  
+
   for (let i = 0; i < expectedSequence.length; i++) {
     const match = tsSequence[i] === expectedSequence[i];
-    console.log(`  Step ${i}: Expected ${expectedSequence[i]}, Got ${tsSequence[i]} - ${match ? "PASS" : "FAIL"}`);
+    console.log(
+      `  Step ${i}: Expected ${expectedSequence[i]}, Got ${tsSequence[i]} - ${match ? "PASS" : "FAIL"}`
+    );
     if (!match) allPassed = false;
   }
-  
+
   console.log(`  → Sequence Test Result: ${allPassed ? "PASS" : "FAIL"}\n`);
-  
+
   return allPassed;
 }
 
 function compareBinaryFormat() {
   console.log("=== BINARY FORMAT COMPARISON ===\n");
-  
+
   // Test exact binary format compatibility
   const testKSUID = KSUID.fromParts(
     0x05a9a844,
     Buffer.from("669f7efd7b6fe812278486085878563d", "hex")
   );
-  
+
   const buffer = testKSUID.toBuffer();
-  
+
   console.log("Binary format validation:");
   console.log(`  Buffer length: ${buffer.length} bytes (expected: 20)`);
-  console.log(`  First 4 bytes (timestamp): ${buffer.subarray(0, 4).toString("hex")}`);
-  console.log(`  Next 16 bytes (payload): ${buffer.subarray(4, 20).toString("hex")}`);
+  console.log(
+    `  First 4 bytes (timestamp): ${buffer.subarray(0, 4).toString("hex")}`
+  );
+  console.log(
+    `  Next 16 bytes (payload): ${buffer.subarray(4, 20).toString("hex")}`
+  );
   console.log(`  Complete buffer: ${buffer.toString("hex")}`);
-  
+
   const lengthCorrect = buffer.length === 20;
   const timestampCorrect = buffer.readUInt32BE(0) === 0x05a9a844;
-  const payloadCorrect = buffer.subarray(4, 20).toString("hex") === "669f7efd7b6fe812278486085878563d";
-  const completeCorrect = buffer.toString("hex") === "05a9a844669f7efd7b6fe812278486085878563d";
-  
+  const payloadCorrect =
+    buffer.subarray(4, 20).toString("hex") ===
+    "669f7efd7b6fe812278486085878563d";
+  const completeCorrect =
+    buffer.toString("hex") === "05a9a844669f7efd7b6fe812278486085878563d";
+
   console.log(`  ✓ Length correct: ${lengthCorrect}`);
   console.log(`  ✓ Timestamp correct: ${timestampCorrect}`);
   console.log(`  ✓ Payload correct: ${payloadCorrect}`);
   console.log(`  ✓ Complete buffer correct: ${completeCorrect}`);
-  
-  const allPassed = lengthCorrect && timestampCorrect && payloadCorrect && completeCorrect;
-  console.log(`  → Binary Format Test Result: ${allPassed ? "PASS" : "FAIL"}\n`);
-  
+
+  const allPassed =
+    lengthCorrect && timestampCorrect && payloadCorrect && completeCorrect;
+  console.log(
+    `  → Binary Format Test Result: ${allPassed ? "PASS" : "FAIL"}\n`
+  );
+
   return allPassed;
 }
 
 function main() {
   console.log("🔍 KSUID Implementation Comparison: Go vs TypeScript\n");
   console.log("This script verifies that the TypeScript @owpz/ksuid library");
-  console.log("generates identical results to the Go segmentio/ksuid library.\n");
-  
+  console.log(
+    "generates identical results to the Go segmentio/ksuid library.\n"
+  );
+
   const results = [
     compareBasicGeneration(),
     compareNextPrevOperations(),
@@ -270,28 +285,34 @@ function main() {
     compareSequenceGeneration(),
     compareBinaryFormat(),
   ];
-  
+
   const allTestsPassed = results.every(result => result);
-  
+
   console.log("=== FINAL RESULTS ===");
   console.log(`Basic Generation: ${results[0] ? "PASS" : "FAIL"}`);
   console.log(`Next/Prev Operations: ${results[1] ? "PASS" : "FAIL"}`);
   console.log(`Timestamp Conversion: ${results[2] ? "PASS" : "FAIL"}`);
   console.log(`Sequence Generation: ${results[3] ? "PASS" : "FAIL"}`);
   console.log(`Binary Format: ${results[4] ? "PASS" : "FAIL"}`);
-  console.log(`\n🎯 Overall Result: ${allTestsPassed ? "ALL TESTS PASS" : "SOME TESTS FAILED"}`);
-  
+  console.log(
+    `\n🎯 Overall Result: ${allTestsPassed ? "ALL TESTS PASS" : "SOME TESTS FAILED"}`
+  );
+
   if (allTestsPassed) {
-    console.log("\n✅ The TypeScript implementation is fully compatible with the Go implementation!");
+    console.log(
+      "\n✅ The TypeScript implementation is fully compatible with the Go implementation!"
+    );
     console.log("   - Timestamps match exactly");
     console.log("   - String representations are identical");
     console.log("   - Binary formats are byte-for-byte identical");
     console.log("   - Next/prev operations behave identically");
     console.log("   - All edge cases handled correctly");
   } else {
-    console.log("\n❌ There are compatibility issues that need to be addressed.");
+    console.log(
+      "\n❌ There are compatibility issues that need to be addressed."
+    );
   }
-  
+
   process.exit(allTestsPassed ? 0 : 1);
 }
 

--- a/test/compare-implementations.ts
+++ b/test/compare-implementations.ts
@@ -1,0 +1,300 @@
+#!/usr/bin/env ts-node
+
+import { KSUID } from "../src/ksuid";
+import { Buffer } from "buffer";
+
+/**
+ * Comprehensive comparison script to verify Go and TypeScript KSUID implementations
+ * generate identical results for timestamps, strings, and all values.
+ */
+
+interface TestVector {
+  description: string;
+  timestamp: number;
+  payload: string;
+  expectedString: string;
+  expectedRaw: string;
+}
+
+// Test vectors generated from Go implementation
+const GO_TEST_VECTORS: TestVector[] = [
+  {
+    description: "Fixed timestamp with known payload",
+    timestamp: 95004740,
+    payload: "669f7efd7b6fe812278486085878563d",
+    expectedString: "0o5sKzFDBc56T8mbUP8wH1KpSX7",
+    expectedRaw: "05a9a844669f7efd7b6fe812278486085878563d",
+  },
+  {
+    description: "Epoch timestamp (KSUID zero time)",
+    timestamp: 0,
+    payload: "deadbeefdeadbeefdeadbeefdeadbeef",
+    expectedString: "000006mBhJfVeGABNuCXRQc2hOZ",
+    expectedRaw: "00000000deadbeefdeadbeefdeadbeefdeadbeef",
+  },
+  {
+    description: "Max timestamp with specific payload",
+    timestamp: 4294967295, // Max uint32
+    payload: "abcdef0123456789abcdef0123456789",
+    expectedString: "aWgEPRC9f9y39AiMcAMCXnpvSIr",
+    expectedRaw: "ffffffffabcdef0123456789abcdef0123456789",
+  },
+];
+
+// Next/Prev test cases from Go
+const NEXT_PREV_VECTORS = [
+  {
+    description: "Standard KSUID next/prev",
+    input: "0o5sKzFDBc56T8mbUP8wH1KpSX7",
+    expectedNext: "0o5sKzFDBc56T8mbUP8wH1KpSX8",
+    expectedPrev: "0o5sKzFDBc56T8mbUP8wH1KpSX6",
+  },
+  {
+    description: "Max payload case",
+    input: "0o5sL3ud7B3uapD0WkI3wf4VhoF",
+    expectedNext: "0o5sL3ud7B3uapD0WkI3wf4VhoG",
+    expectedPrev: "0o5sL3ud7B3uapD0WkI3wf4VhoE",
+  },
+  {
+    description: "Nil payload case",
+    input: "0o5sKw7Z4xnYVLXEmaUv9lxG0C8",
+    expectedNext: "0o5sKw7Z4xnYVLXEmaUv9lxG0C9",
+    expectedPrev: "0o5sKw7Z4xnYVLXEmaUv9lxG0C7",
+  },
+  {
+    description: "Nil KSUID edge case",
+    input: "000000000000000000000000000",
+    expectedNext: "000000000000000000000000001",
+    expectedPrev: "aWgEPTl1tmebfsQzFP4bxwgy80V",
+  },
+];
+
+function compareBasicGeneration() {
+  console.log("=== BASIC GENERATION COMPARISON ===\n");
+  
+  let allPassed = true;
+  
+  for (const testCase of GO_TEST_VECTORS) {
+    console.log(`Testing: ${testCase.description}`);
+    
+    const payload = Buffer.from(testCase.payload, "hex");
+    const tsKsuid = KSUID.fromParts(testCase.timestamp, payload);
+    
+    // Compare timestamp extraction
+    const extractedTimestamp = tsKsuid.timestamp;
+    console.log(`  Input timestamp: ${testCase.timestamp}`);
+    console.log(`  Extracted timestamp: ${extractedTimestamp}`);
+    const timestampMatch = extractedTimestamp === testCase.timestamp;
+    console.log(`  ✓ Timestamp match: ${timestampMatch}`);
+    
+    // Compare string representation
+    const tsString = tsKsuid.toString();
+    console.log(`  Expected string: ${testCase.expectedString}`);
+    console.log(`  Generated string: ${tsString}`);
+    const stringMatch = tsString === testCase.expectedString;
+    console.log(`  ✓ String match: ${stringMatch}`);
+    
+    // Compare raw buffer
+    const tsRaw = tsKsuid.toBuffer().toString("hex");
+    console.log(`  Expected raw: ${testCase.expectedRaw}`);
+    console.log(`  Generated raw: ${tsRaw}`);
+    const rawMatch = tsRaw === testCase.expectedRaw;
+    console.log(`  ✓ Raw bytes match: ${rawMatch}`);
+    
+    // Compare payload extraction
+    const extractedPayload = tsKsuid.payload.toString("hex");
+    console.log(`  Input payload: ${testCase.payload}`);
+    console.log(`  Extracted payload: ${extractedPayload}`);
+    const payloadMatch = extractedPayload === testCase.payload;
+    console.log(`  ✓ Payload match: ${payloadMatch}`);
+    
+    const testPassed = timestampMatch && stringMatch && rawMatch && payloadMatch;
+    console.log(`  → Test Result: ${testPassed ? "PASS" : "FAIL"}\n`);
+    
+    if (!testPassed) allPassed = false;
+  }
+  
+  return allPassed;
+}
+
+function compareNextPrevOperations() {
+  console.log("=== NEXT/PREV OPERATIONS COMPARISON ===\n");
+  
+  let allPassed = true;
+  
+  for (const testCase of NEXT_PREV_VECTORS) {
+    console.log(`Testing: ${testCase.description}`);
+    
+    const ksuid = KSUID.parse(testCase.input);
+    const next = ksuid.next();
+    const prev = ksuid.prev();
+    
+    console.log(`  Input: ${testCase.input}`);
+    console.log(`  Expected next: ${testCase.expectedNext}`);
+    console.log(`  Generated next: ${next.toString()}`);
+    const nextMatch = next.toString() === testCase.expectedNext;
+    console.log(`  ✓ Next match: ${nextMatch}`);
+    
+    console.log(`  Expected prev: ${testCase.expectedPrev}`);
+    console.log(`  Generated prev: ${prev.toString()}`);
+    const prevMatch = prev.toString() === testCase.expectedPrev;
+    console.log(`  ✓ Prev match: ${prevMatch}`);
+    
+    const testPassed = nextMatch && prevMatch;
+    console.log(`  → Test Result: ${testPassed ? "PASS" : "FAIL"}\n`);
+    
+    if (!testPassed) allPassed = false;
+  }
+  
+  return allPassed;
+}
+
+function compareTimestampConversion() {
+  console.log("=== TIMESTAMP CONVERSION COMPARISON ===\n");
+  
+  const KSUID_EPOCH = 1400000000; // 2014-05-13T16:53:20Z
+  
+  const testCases = [
+    { ksuidTimestamp: 0, description: "KSUID epoch" },
+    { ksuidTimestamp: 95004740, description: "Standard timestamp" },
+    { ksuidTimestamp: 4294967295, description: "Maximum timestamp" },
+  ];
+  
+  let allPassed = true;
+  
+  for (const testCase of testCases) {
+    console.log(`Testing: ${testCase.description}`);
+    
+    const ksuid = KSUID.fromParts(testCase.ksuidTimestamp, Buffer.alloc(16, 0));
+    const extractedTimestamp = ksuid.timestamp;
+    const unixTimestamp = extractedTimestamp + KSUID_EPOCH;
+    const expectedUnixTimestamp = testCase.ksuidTimestamp + KSUID_EPOCH;
+    
+    console.log(`  KSUID timestamp: ${testCase.ksuidTimestamp}`);
+    console.log(`  Extracted timestamp: ${extractedTimestamp}`);
+    console.log(`  Calculated Unix timestamp: ${unixTimestamp}`);
+    console.log(`  Expected Unix timestamp: ${expectedUnixTimestamp}`);
+    
+    const timestampMatch = extractedTimestamp === testCase.ksuidTimestamp;
+    const unixMatch = unixTimestamp === expectedUnixTimestamp;
+    
+    console.log(`  ✓ KSUID timestamp match: ${timestampMatch}`);
+    console.log(`  ✓ Unix timestamp match: ${unixMatch}`);
+    
+    const testPassed = timestampMatch && unixMatch;
+    console.log(`  → Test Result: ${testPassed ? "PASS" : "FAIL"}\n`);
+    
+    if (!testPassed) allPassed = false;
+  }
+  
+  return allPassed;
+}
+
+function compareSequenceGeneration() {
+  console.log("=== SEQUENCE GENERATION COMPARISON ===\n");
+  
+  // Go sequence test vectors
+  const expectedSequence = [
+    "0o5sKzFDBc56T8mbUP8wH1KpSX7",
+    "0o5sKzFDBc56T8mbUP8wH1KpSX8",
+    "0o5sKzFDBc56T8mbUP8wH1KpSX9",
+    "0o5sKzFDBc56T8mbUP8wH1KpSXA",
+    "0o5sKzFDBc56T8mbUP8wH1KpSXB",
+  ];
+  
+  // Generate sequence using next() method
+  let current = KSUID.parse(expectedSequence[0]);
+  const tsSequence = [current.toString()];
+  
+  for (let i = 1; i < expectedSequence.length; i++) {
+    current = current.next();
+    tsSequence.push(current.toString());
+  }
+  
+  console.log("Comparing sequence generation:");
+  let allPassed = true;
+  
+  for (let i = 0; i < expectedSequence.length; i++) {
+    const match = tsSequence[i] === expectedSequence[i];
+    console.log(`  Step ${i}: Expected ${expectedSequence[i]}, Got ${tsSequence[i]} - ${match ? "PASS" : "FAIL"}`);
+    if (!match) allPassed = false;
+  }
+  
+  console.log(`  → Sequence Test Result: ${allPassed ? "PASS" : "FAIL"}\n`);
+  
+  return allPassed;
+}
+
+function compareBinaryFormat() {
+  console.log("=== BINARY FORMAT COMPARISON ===\n");
+  
+  // Test exact binary format compatibility
+  const testKSUID = KSUID.fromParts(
+    0x05a9a844,
+    Buffer.from("669f7efd7b6fe812278486085878563d", "hex")
+  );
+  
+  const buffer = testKSUID.toBuffer();
+  
+  console.log("Binary format validation:");
+  console.log(`  Buffer length: ${buffer.length} bytes (expected: 20)`);
+  console.log(`  First 4 bytes (timestamp): ${buffer.subarray(0, 4).toString("hex")}`);
+  console.log(`  Next 16 bytes (payload): ${buffer.subarray(4, 20).toString("hex")}`);
+  console.log(`  Complete buffer: ${buffer.toString("hex")}`);
+  
+  const lengthCorrect = buffer.length === 20;
+  const timestampCorrect = buffer.readUInt32BE(0) === 0x05a9a844;
+  const payloadCorrect = buffer.subarray(4, 20).toString("hex") === "669f7efd7b6fe812278486085878563d";
+  const completeCorrect = buffer.toString("hex") === "05a9a844669f7efd7b6fe812278486085878563d";
+  
+  console.log(`  ✓ Length correct: ${lengthCorrect}`);
+  console.log(`  ✓ Timestamp correct: ${timestampCorrect}`);
+  console.log(`  ✓ Payload correct: ${payloadCorrect}`);
+  console.log(`  ✓ Complete buffer correct: ${completeCorrect}`);
+  
+  const allPassed = lengthCorrect && timestampCorrect && payloadCorrect && completeCorrect;
+  console.log(`  → Binary Format Test Result: ${allPassed ? "PASS" : "FAIL"}\n`);
+  
+  return allPassed;
+}
+
+function main() {
+  console.log("🔍 KSUID Implementation Comparison: Go vs TypeScript\n");
+  console.log("This script verifies that the TypeScript @owpz/ksuid library");
+  console.log("generates identical results to the Go segmentio/ksuid library.\n");
+  
+  const results = [
+    compareBasicGeneration(),
+    compareNextPrevOperations(),
+    compareTimestampConversion(),
+    compareSequenceGeneration(),
+    compareBinaryFormat(),
+  ];
+  
+  const allTestsPassed = results.every(result => result);
+  
+  console.log("=== FINAL RESULTS ===");
+  console.log(`Basic Generation: ${results[0] ? "PASS" : "FAIL"}`);
+  console.log(`Next/Prev Operations: ${results[1] ? "PASS" : "FAIL"}`);
+  console.log(`Timestamp Conversion: ${results[2] ? "PASS" : "FAIL"}`);
+  console.log(`Sequence Generation: ${results[3] ? "PASS" : "FAIL"}`);
+  console.log(`Binary Format: ${results[4] ? "PASS" : "FAIL"}`);
+  console.log(`\n🎯 Overall Result: ${allTestsPassed ? "ALL TESTS PASS" : "SOME TESTS FAILED"}`);
+  
+  if (allTestsPassed) {
+    console.log("\n✅ The TypeScript implementation is fully compatible with the Go implementation!");
+    console.log("   - Timestamps match exactly");
+    console.log("   - String representations are identical");
+    console.log("   - Binary formats are byte-for-byte identical");
+    console.log("   - Next/prev operations behave identically");
+    console.log("   - All edge cases handled correctly");
+  } else {
+    console.log("\n❌ There are compatibility issues that need to be addressed.");
+  }
+  
+  process.exit(allTestsPassed ? 0 : 1);
+}
+
+if (require.main === module) {
+  main();
+}

--- a/test/performance/benchmark.ts
+++ b/test/performance/benchmark.ts
@@ -212,13 +212,13 @@ async function runBenchmarks(): Promise<void> {
   let accessIndex = 0;
   await benchmark.run("Timestamp Access", 100000, () => {
     const ksuid = testKsuids[accessIndex++ % testKsuids.length];
-    ksuid.timestamp;
+    void ksuid.timestamp; // Explicitly void to indicate intentional unused access
   });
 
   let payloadIndex = 0;
   await benchmark.run("Payload Access", 100000, () => {
     const ksuid = testKsuids[payloadIndex++ % testKsuids.length];
-    ksuid.payload;
+    void ksuid.payload; // Explicitly void to indicate intentional unused access
   });
 
   // Print results

--- a/test/performance/compare.ts
+++ b/test/performance/compare.ts
@@ -50,7 +50,6 @@ class PerformanceComparison {
     console.log("📊 Step 1: Running TypeScript benchmark...");
 
     // Run TypeScript benchmark and capture results
-    const tsBenchmarkPath = join(perfDir, "benchmark.ts");
     try {
       execSync(`npm run benchmark`, {
         cwd: rootDir,
@@ -82,7 +81,6 @@ class PerformanceComparison {
     console.log("\n📊 Step 2: Setting up Go benchmark...");
 
     // Initialize Go module and get dependencies
-    const goBenchmarkPath = join(perfDir, "go-benchmark.go");
     const goModPath = join(perfDir, "go.mod");
 
     if (!existsSync(goModPath)) {

--- a/test/unit/error-handling.test.ts
+++ b/test/unit/error-handling.test.ts
@@ -115,7 +115,6 @@ test("CompressedSet error handling", () => {
 
   // Test with invalid compressed data during iteration
   const invalidSet = CompressedSet.fromBuffer(Buffer.from([0xff, 0xff, 0xff]));
-  const invalidIter = invalidSet.iter();
   // This may not throw immediately - the error might occur during iteration
   // Let's just test that we can create the set without errors
   assert.ok(invalidSet instanceof CompressedSet);

--- a/test/unit/uint128.test.ts
+++ b/test/unit/uint128.test.ts
@@ -74,9 +74,6 @@ test("Uint128 addition operations", () => {
 
 test("Uint128 addition with carry", () => {
   // Test carry propagation across 64-bit boundary
-  const a = Uint128.makeUint128FromPayload(
-    Buffer.from("00000000000000000000000000000000", "hex")
-  );
   const b = Uint128.makeUint128FromPayload(
     Buffer.from("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", "hex")
   );


### PR DESCRIPTION
# Pull Request

## 📋 Summary

Brief description of what this PR does and why it's needed.

## 🔧 Type of Change

- [X] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test improvements
- [ ] 🔧 Build/CI changes

## 🧪 Testing

- [X] Added new tests for the changes
- [X] All existing tests pass (`npm test`)
- [X] Go compatibility tests pass (if applicable)
- [ ] Manual testing completed
- [X] Cross-validation with Go implementation (if applicable)

**Test Results:**

```
npm test
# Paste test output here if there are failures

> @owpz/ksuid@25.7.20 test
> uvu -r ts-node/register test

[1m[4m[37mapi-contract/api-contract.test.ts[22m[24m[39m
[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[32m  (16 / 16)
[39m
[1m[4m[37mapi-contract/cli-contract.test.ts[22m[24m[39m
[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[32m  (19 / 19)
[39m
[1m[4m[37mapi-contract/run-all-contract-tests.js[22m[24m[39m

[1m[4m[37mapi-contract/type-contract.test.ts[22m[24m[39m
[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[32m  (15 / 15)
[39m
[1m[4m[37mcompare-implementations.ts[22m[24m[39m

[1m[4m[37mintegration/go-compatibility.test.ts[22m[24m[39m
[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[32m  (9 / 9)
[39m
[1m[4m[37mintegration/go-interop.test.ts[22m[24m[39m
[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[32m  (10 / 10)
[39m
[1m[4m[37mperformance/benchmark.ts[22m[24m[39m

[1m[4m[37mperformance/compare.ts[22m[24m[39m

[1m[4m[37mperformance/regression.ts[22m[24m[39m

[1m[4m[37mperformance/stress-test.ts[22m[24m[39m

[1m[4m[37munit/base62.test.ts[22m[24m[39m
All-zero KSUID encoding: 000000000000000000000000000
[90m• [39mLeading-zero KSUID encoding: 000000000000000000000000BRN
[90m• [39mMax KSUID encoding: aWgEPTl1tmebfsQzFP4bxwgy80V
[90m• [39mKSUID (randomish): 0o5sKzFDBc56T8mbUP8wH1KpSX7
[90m• [39m[90m• [39m[90m• [39m[90m• [39m[32m  (7 / 7)
[39m
[1m[4m[37munit/compressed-set.test.ts[22m[24m[39m
[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39mExpected length: [33m10[39m Actual length: [33m10[39m
Original KSUIDs: [
  [32m'0o5sKw7Z4xnYVLXEmaUv9lxG0C8'[39m,
  [32m'0o5sXVHy6KHoKV0yOm6vabUe3d3'[39m,
  [32m'0o5sk4SN7gm49eUi0xiw1R2273y'[39m,
  [32m'0o5swdcm93GJynyRd9KwSGZQAUt'[39m,
  [32m'0o5t9CnBAPkZnxSBFKwwt66oDvo'[39m,
  [32m'0o5tLlxaBmEpd6vurWYxJveCHMj'[39m,
  [32m'0o5tYL7zD8j5SGPeTiAxklBaKne'[39m,
  [32m'0o5tkuIOEVDLHPtO5tmyBaiyOEZ'[39m,
  [32m'0o5txTSnFrhb6ZN7i5OycQGMRfU'[39m,
  [32m'0o5uA2dCHEBqviqrKH0z3FnkV6P'[39m
]
Result KSUIDs: [
  [32m'0o5sKw7Z4xnYVLXEmaUv9lxG0C8'[39m,
  [32m'0o5sXVHy6KHoKV0yOm6vabUe3d3'[39m,
  [32m'0o5sk4SN7gm49eUi0xiw1R2273y'[39m,
  [32m'0o5swdcm93GJynyRd9KwSGZQAUt'[39m,
  [32m'0o5t9CnBAPkZnxSBFKwwt66oDvo'[39m,
  [32m'0o5tLlxaBmEpd6vurWYxJveCHMj'[39m,
  [32m'0o5tYL7zD8j5SGPeTiAxklBaKne'[39m,
  [32m'0o5tkuIOEVDLHPtO5tmyBaiyOEZ'[39m,
  [32m'0o5txTSnFrhb6ZN7i5OycQGMRfU'[39m,
  [32m'0o5uA2dCHEBqviqrKH0z3FnkV6P'[39m
]
[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[32m  (11 / 11)
[39m
[1m[4m[37munit/error-handling.test.ts[22m[24m[39m
[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[32m  (12 / 12)
[39m
[1m[4m[37munit/ksuid.constructors.test.ts[22m[24m[39m
[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[32m  (12 / 12)
[39m
[1m[4m[37munit/ksuid.generate.test.ts[22m[24m[39m
KSUID String:      0o5sKzFDBc56T8mbUP8wH1KpSX7
Timestamp:         [33m95004740[39m
Payload (hex):     669f7efd7b6fe812278486085878563d
Raw Buffer (hex):  05a9a844669f7efd7b6fe812278486085878563d
[90m• [39m[32m  (1 / 1)
[39m
[1m[4m[37munit/ksuid.next-prev.test.ts[22m[24m[39m
[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[32m  (7 / 7)
[39m
[1m[4m[37munit/ksuid.test.ts[22m[24m[39m
[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[32m  (13 / 13)
[39m
[1m[4m[37munit/sequence.test.ts[22m[24m[39m
[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[32m  (7 / 7)
[39m
[1m[4m[37munit/sort.test.ts[22m[24m[39m
[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[32m  (12 / 12)
[39m
[1m[4m[37munit/template-sync.test.ts[22m[24m[39m
[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[32m  (10 / 10)
[39m
[1m[4m[37munit/uint128.test.ts[22m[24m[39m
[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[90m• [39m[32m  (19 / 19)
[39m
  Total:     180[32m
  Passed:    180[39m
  Skipped:   0
  Duration:  24871.78ms


```

## 📚 Documentation

- [ ] Updated README.md (if applicable)
- [ ] Updated JSDoc comments
- [ ] Added usage examples (if applicable)
- [ ] Updated CONTRIBUTING.md (if applicable)
- [ ] Updated CHANGELOG.md (if applicable)

## 🎯 Go Compatibility

**Required for changes affecting KSUID behavior:**

- [ ] Validated against Go implementation using `docs/validation/` tools
- [ ] Test vectors updated (if behavior changed)
- [ ] Cross-validation tests pass
- [ ] CLI output matches Go CLI (if applicable)

**Go validation results:**

```bash
# Run and paste results from docs/validation/cross-validate.sh
```

## 🔍 Code Quality

- [ ] Code follows project style guidelines
- [ ] TypeScript strict mode compliance
- [ ] No linting errors (`npm run lint`)
- [ ] No TypeScript errors (`npm run type-check`)
- [ ] Self-review completed
- [ ] No hardcoded values or magic numbers
- [ ] Proper error handling

## 📖 Details

### What changed?
Resolves codeql code scanning vulnerabilities
-

### Why was this change needed?

-

### How was it implemented?

-

### Any potential side effects or breaking changes?

-

## 🔗 Related Issues

Closes #(issue number) Relates to #(issue number)

## 📸 Screenshots (if applicable)

<!-- Add screenshots for UI changes or CLI output -->

## ✅ Checklist

- [X] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [X] My code follows the project's coding standards
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings or errors
- [X] Any dependent changes have been merged and published

## 🚨 Breaking Changes

**If this is a breaking change, describe:**
 ot breaking change
---

**Note for maintainers:** Please ensure Go compatibility is maintained before merging.
