### PR TITLE
fix: validate compressed PAYLOAD_RANGE lengths to prevent iterator DoS

### DIFF
--- a/src/compressed-set.ts
+++ b/src/compressed-set.ts
@@ -395,6 +395,10 @@ export class CompressedSetIter {
       }
 
       case PAYLOAD_RANGE: {
+        if (cnt === 0 || cnt > 8) {
+          throw KSUIDError.malformedData("invalid range length encoding");
+        }
+
         // Read range length
         const lengthBuffer = this.content.subarray(
           this.offset,
@@ -403,9 +407,13 @@ export class CompressedSetIter {
         const rangeLength = this.readVarint64(lengthBuffer);
         this.offset += cnt;
 
+        if (rangeLength < 1n || rangeLength > BigInt(Number.MAX_SAFE_INTEGER)) {
+          throw KSUIDError.malformedData("range length out of bounds");
+        }
+
         const value = this.lastValue.incr();
         this.ksuid = KSUID.fromBytes(value.ksuid(this.timestamp));
-        this.seqlength = rangeLength - 1;
+        this.seqlength = Number(rangeLength - 1n);
         this.lastValue = value;
         break;
       }
@@ -425,10 +433,10 @@ export class CompressedSetIter {
     return temp.readUInt32BE(0);
   }
 
-  private readVarint64(buffer: Buffer): number {
+  private readVarint64(buffer: Buffer): bigint {
     const temp = Buffer.alloc(8);
     buffer.copy(temp, 8 - buffer.length);
-    return Number(temp.readBigUInt64BE(0));
+    return temp.readBigUInt64BE(0);
   }
 
   private readVarint128(buffer: Buffer): Uint128 {

--- a/test/unit/compressed-set.test.ts
+++ b/test/unit/compressed-set.test.ts
@@ -235,4 +235,19 @@ test("CompressedSet toString format", () => {
   assert.ok(str.includes('"'));
 });
 
+test("CompressedSet rejects oversized range length payloads", () => {
+  const base = KSUID.fromParts(95004740, Buffer.alloc(16));
+  const rawEntry = Buffer.concat([Buffer.from([0]), base.toBuffer()]);
+  const hugeRange = Buffer.from([0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
+  const payloadRangeEntry = Buffer.concat([Buffer.from([0xc8]), hugeRange]);
+  const malformed = Buffer.concat([rawEntry, payloadRangeEntry]);
+
+  const set = CompressedSet.fromBuffer(malformed);
+
+  assert.throws(
+    () => set.toArray(),
+    /Malformed data detected: range length out of bounds/
+  );
+});
+
 test.run();


### PR DESCRIPTION
### Motivation
- The iterator previously converted attacker-controlled 64-bit `PAYLOAD_RANGE` lengths directly to `number` and assigned them to `seqlength` without validation, allowing precision loss and unbounded/non-decrementing iteration that enables CPU/memory exhaustion.

### Description
- Reject invalid varint byte counts for `PAYLOAD_RANGE` by validating `cnt` is between `1` and `8` and throwing `KSUIDError.malformedData` for out-of-range encodings in `CompressedSetIter`.
- Change `readVarint64` to return a `bigint` instead of `number` and use that `bigint` to enforce `1 <= rangeLength <= Number.MAX_SAFE_INTEGER` before converting to `number` for `seqlength`.
- Convert the validated `rangeLength` to `number` using `Number(rangeLength - 1n)` when assigning `seqlength` to avoid precision loss and unbounded iteration.
- Add a unit test `CompressedSet rejects oversized range length payloads` that crafts a malformed compressed buffer with an oversized `PAYLOAD_RANGE` and asserts `toArray()` throws a malformed-data error.

### Testing
- Ran the new test file directly with `node -r ts-node/register test/unit/compressed-set.test.ts`, and the compressed-set tests (including the new malformed-range test) passed.
- Built the project with `npm run build` and the TypeScript compilation succeeded.
- Ran the full unit test suite with `npm run test:unit`; the run shows existing unrelated failures in `test/unit/template-sync.test.ts` (pre-existing noisy stdout warnings), and the changes introduced here did not cause new compressed-set failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af17ad7f6c832c8bf079db7c100c1c)